### PR TITLE
Specify schema in addon configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,19 @@
     "config": {
       "mqtt": "mqtt://localhost",
       "prefix": "zigbee2mqtt"
+    },
+    "schema": {
+      "type": "object",
+      "properties": {
+        "mqtt": {
+          "type": "string",
+          "description": "Mosquitto or other mqtt server host/port to connect to"
+        },
+        "prefix": {
+          "type": "string",
+          "description": "Mqtt topic prefix for zigbee2mqtt"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This adds the schema directive for exposing the config options in the GUI.

<img width="491" alt="Screen Shot 2019-05-21 at 10 32 08 PM" src="https://user-images.githubusercontent.com/233396/58149747-061b7480-7c19-11e9-9e75-e2e462ae97b4.png">

P.S. Thanks for sharing! I got it working well with my Philips Hue devices, although I had to change some of the modelId handling, not sure if it's device-specific or a difference in zigbee2mqtt versions but I'll experiment more before submitting a PR. So far I'm definitely liking WebThings over Home Assistant, Nodered, Domoticz, etc (for my use cases).