### PR TITLE
Aquara lumi.weather sensor, Optimizations for Zigbee2Mqtt

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -126,4 +126,41 @@ module.exports = {
       },
     },
   },
+  'lumi.weather': {
+    name: 'Xiaomi Aquara Temperature & Humidity & Pressure Sensor',
+    '@type': ['TemperatureSensor'],
+    properties: {
+      battery: {
+        type: 'integer',
+        unit: 'percent',
+        minimum: 0,
+        maximum: 100,
+        readOnly: true,
+      },
+      linkquality: {
+        type: 'integer',
+        readOnly: true,
+      },
+      temperature: {
+        type: 'number',
+        '@type': 'TemperatureProperty',
+        unit: 'degree celsius',
+	multipleOf: 0.1,
+        readOnly: true,
+      },
+      humidity: {
+        type: 'number',
+        unit: 'percent',
+	multipleOf: 0.5,
+        readOnly: true,
+      },
+      pressure: {
+        type: 'number',
+        unit: 'hPa',
+	multipleOf: 0.5,
+        readOnly: true,
+      },
+    },
+  },
+
 };

--- a/zigbee2mqtt-adapter.js
+++ b/zigbee2mqtt-adapter.js
@@ -44,10 +44,12 @@ class MqttProperty extends Property {
 }
 
 class MqttDevice extends Device {
-  constructor(adapter, id, description) {
+  constructor(adapter, id, modelId) {
     super(adapter, id);
+    const description = Devices[modelId];
     this.name = description.name;
     this['@type'] = description['@type'];
+    this.modelId = modelId;
     for (const [name, desc] of Object.entries(description.properties || {})) {
       const property = new MqttProperty(this, name, desc);
       this.properties.set(name, property);
@@ -68,7 +70,6 @@ class ZigbeeMqttAdapter extends Adapter {
     this.client.on('error', error => console.error('mqtt error', error));
     this.client.on('message', this.handleIncomingMessage.bind(this));
     this.client.subscribe(`${this.config.prefix}/bridge/config/devices`);
-    this.client.subscribe(`${this.config.prefix}/+`);
     this.client.publish(`${this.config.prefix}/bridge/config/devices/get`);
   }
 
@@ -80,16 +81,17 @@ class ZigbeeMqttAdapter extends Adapter {
       }
     }
     if (!topic.startsWith(`${this.config.prefix}/bridge`)) {
-      const description = Devices[msg.device.modelId];
-      const device = this.devices[msg.device.friendlyName];
+      const topicElements = topic.split('/');
+      const friendlyName = topicElements[topicElements.length - 1]; 
+      const device = this.getDevice(friendlyName);
       if (!device) {
         return;
       }
-      if (msg.action && description.events[msg.action]) {
+      if (msg.action && device.events.get(msg.action)) {
         const event = new Event(
           device,
           msg.action,
-          msg[description.events[msg.action]],
+          msg[device.events.get(msg.action)],
         );
         device.eventNotify(event);
       }
@@ -98,7 +100,7 @@ class ZigbeeMqttAdapter extends Adapter {
         if (!property) {
           continue;
         }
-        const { fromMqtt = identity } = description.properties[key];
+        const { fromMqtt = identity } = property.options;
         property.setCachedValue(fromMqtt(msg[key]));
         device.notifyPropertyChanged(property);
       }
@@ -110,11 +112,18 @@ class ZigbeeMqttAdapter extends Adapter {
   }
 
   addDevice(info) {
-    const description = Devices[info.modelId];
-    if (!description) {
+    if (!Devices[info.modelID]) {
+      // No definition for the given model ID. Skipping.
       return;
     }
-    const device = new MqttDevice(this, info.friendly_name, description);
+    const existingDevice = this.getDevice(info.friendly_name);
+    if (existingDevice && existingDevice.modelId === info.modelID) {
+      console.info(`Device ${info.friendly_name} already exists`)
+      return;
+    }
+
+    const device = new MqttDevice(this, info.friendly_name, info.modelID);
+    this.client.subscribe(`${this.config.prefix}/${info.friendly_name}`);
     this.handleDeviceAdded(device);
   }
 
@@ -133,3 +142,4 @@ function loadAdapter(addonManager, manifest, _errorCallback) {
 }
 
 module.exports = loadAdapter;
+


### PR DESCRIPTION
* Add support for aquara weather sensor 'modelID' = 'lumi.weather'
* Correct 'modelId' property -> 'modelID' to make it work with latest zigbee2mqtt messages
* Make the adaptor work with default zigbee2mqtt configuration without the 'include_device_information' option