### PR TITLE
Support devices with / in their names

### DIFF
--- a/zigbee2mqtt-adapter.js
+++ b/zigbee2mqtt-adapter.js
@@ -81,8 +81,7 @@ class ZigbeeMqttAdapter extends Adapter {
       }
     }
     if (!topic.startsWith(`${this.config.prefix}/bridge`)) {
-      const topicElements = topic.split('/');
-      const friendlyName = topicElements[topicElements.length - 1]; 
+      const friendlyName = topic.replace(`${this.config.prefix}/`, '');
       const device = this.getDevice(friendlyName);
       if (!device) {
         return;


### PR DESCRIPTION
My devices have a slash in their names, e.g. "sensors/temp_1". Because of the way how the code extracts the friendly name from the topic, my devices are detected but their values are not updated.

The provided patch changes the way how to extract the friendly name from a topic to also support names with a slash.