### PR TITLE
fix(devices.js): add new events since handling changed in zigbee2mqtt

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -498,6 +498,42 @@ module.exports = {
 			scene_6: {
 				'@type': 'PressedEvent',
 			},
+			on_l1: {
+				'@type': 'PressedEvent',
+			},
+			on_l2: {
+				'@type': 'PressedEvent',
+			},
+			on_l3: {
+				'@type': 'PressedEvent',
+			},
+			on_l4: {
+				'@type': 'PressedEvent',
+			},
+			on_l5: {
+				'@type': 'PressedEvent',
+			},
+			on_l6: {
+				'@type': 'PressedEvent',
+			},
+			off_l1: {
+				'@type': 'PressedEvent',
+			},
+			off_l2: {
+				'@type': 'PressedEvent',
+			},
+			off_l3: {
+				'@type': 'PressedEvent',
+			},
+			off_l4: {
+				'@type': 'PressedEvent',
+			},
+			off_l5: {
+				'@type': 'PressedEvent',
+			},
+			off_l6: {
+				'@type': 'PressedEvent',
+			},
 		},
 	},
 };


### PR DESCRIPTION
Greetings.
Since the handling in zigbee2mqtt has changed regarding the Innr RC 110 remote, new events are added.
When pressing one of the light buttons, simply an event is generated instead of setting a property value.
I have tested this on my deployment and works just fine.